### PR TITLE
#6 - Merge changed from last two releases into a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.2] - 2024-03-18
-### Fixed
-- Fix Drupal version requirement
-### Changed
-- Bump PHP version to `8.1`
-
-## [1.3.1] - 2024-03-15
+## [1.3.1] - 2024-03-19
 ### Fixed
 - Fix Drupal deprecations
+### Changed
+- Bump PHP version to `8.1`
 
 ## [1.2.5] - 2021-08-30
 ### Added


### PR DESCRIPTION
We first released `1.3.1` without a fix of Drupal version requirement, fix that we did in `1.3.2`, so now we will delete both `1.3.1` and `1.3.2` and release a new `1.3.1`.