### PR TITLE
Accessibility features dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2024-10-15
+### Added
+- Support GuzzleHttp versions bellow 8.0
+- Support Drupal ^9.3
+- Add title attribute to iframe tag
+- Add `keyboard` query parameter to vimeo embed URL
+- Add `disablekb` attribute to YouTube iframe
+
 ## [1.4.0] - 2024-03-25
 ### Added
 - Support YouTube Shorts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support GuzzleHttp versions below 8.0
 - Support Drupal ^9.3
-- Add title attribute to iframe tag
-- Add `keyboard` query parameter to vimeo embed URL
-- Add `disablekb` attribute to YouTube iframe
+- `embedVideo` twig function now allows adding `title` attribute to iframe tag
+- `embedVideo` twig function now allows you to disable keyboard to prevent interference with help technology
+    - Add `keyboard` query parameter to vimeo embed URL
+    - Add `disablekb` attribute to YouTube iframe
 
 ## [1.4.0] - 2024-03-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2024-10-15
 ### Added
-- Support GuzzleHttp versions bellow 8.0
+- Support GuzzleHttp versions below 8.0
 - Support Drupal ^9.3
 - Add title attribute to iframe tag
 - Add `keyboard` query parameter to vimeo embed URL

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ installed using Composer:
  composer require wieni/wmvideo
 ```
 
+## Usage in twig
+example:
+
+```twig
+{# parameters: $url, $autoplay = false, $width = 640, $height = 360, $disableKeyboard = true, $title = null #}
+{{ embedVideo(video.getLink(), false, 640, 360, true, video.getTitle()) }}
+```
+
 ## Changelog
 All notable changes to this project will be documented in the
 [CHANGELOG](CHANGELOG.md) file.

--- a/src/Plugin/Filter/EmbedVimeoFilter.php
+++ b/src/Plugin/Filter/EmbedVimeoFilter.php
@@ -53,6 +53,7 @@ class EmbedVimeoFilter extends FilterBase
             '#vid' => $vid,
             '#width' => $width,
             '#height' => $height,
+            '#keyboard' => 'false',
         ];
 
         return $this->renderer->render($build);

--- a/src/Plugin/Filter/EmbedYouTubeFilter.php
+++ b/src/Plugin/Filter/EmbedYouTubeFilter.php
@@ -68,6 +68,7 @@ class EmbedYouTubeFilter extends FilterBase
             '#height' => $height,
             '#lang' => $lang,
             '#domain' => $domain,
+            '#disablekb' => '1',
         ];
 
         return $this->renderer->render($build);

--- a/src/Service/VideoInfo.php
+++ b/src/Service/VideoInfo.php
@@ -5,7 +5,6 @@ namespace Drupal\wmvideo\Service;
 use Drupal\wmvideo\VideoEmbedder;
 use GuzzleHttp\Client;
 use GuzzleHttp\Utils;
-use function GuzzleHttp\json_decode;
 use GuzzleHttp\RequestOptions;
 use Symfony\Component\HttpFoundation\RequestStack;
 

--- a/src/Service/VideoInfo.php
+++ b/src/Service/VideoInfo.php
@@ -5,6 +5,7 @@ namespace Drupal\wmvideo\Service;
 use Drupal\wmvideo\VideoEmbedder;
 use GuzzleHttp\Client;
 use GuzzleHttp\Utils;
+use function GuzzleHttp\json_decode;
 use GuzzleHttp\RequestOptions;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -46,7 +47,11 @@ class VideoInfo
 
         try {
             $response = $this->client->get($url, $options);
-            $body = Utils::jsonDecode($response->getBody()->getContents(), true);
+            if (method_exists(Utils::class, 'jsonDecode')) {
+                $body = Utils::jsonDecode($response->getBody()->getContents(), true);
+            } else {
+                $body = json_decode($response->getBody()->getContents(), true);
+            }
         } catch (\Exception $e) {
             return null;
         }

--- a/src/TwigExtension/VideoEmbedExtension.php
+++ b/src/TwigExtension/VideoEmbedExtension.php
@@ -19,8 +19,8 @@ class VideoEmbedExtension extends AbstractExtension
         ];
     }
 
-    public function embedVideo($url, $autoplay = false, $width = 640, $height = 360): ?array
+    public function embedVideo($url, $autoplay = false, $width = 640, $height = 360, $disableKeyboard = true): ?array
     {
-        return VideoEmbedder::create($url, $autoplay, $width, $height);
+        return VideoEmbedder::create($url, $autoplay, $width, $height, $disableKeyboard);
     }
 }

--- a/src/TwigExtension/VideoEmbedExtension.php
+++ b/src/TwigExtension/VideoEmbedExtension.php
@@ -19,8 +19,8 @@ class VideoEmbedExtension extends AbstractExtension
         ];
     }
 
-    public function embedVideo($url, $autoplay = false, $width = 640, $height = 360, $disableKeyboard = true): ?array
+    public function embedVideo($url, $autoplay = false, $width = 640, $height = 360, $disableKeyboard = true, $title = null): ?array
     {
-        return VideoEmbedder::create($url, $autoplay, $width, $height, $disableKeyboard);
+        return VideoEmbedder::create($url, $autoplay, $width, $height, $disableKeyboard, $title);
     }
 }

--- a/src/VideoEmbedder.php
+++ b/src/VideoEmbedder.php
@@ -35,6 +35,10 @@ class VideoEmbedder
                 '#domain' => $domain,
                 '#disablekb' => $disableKeyboard ? '1' : '0',
             ];
+
+            if ($title) {
+                $build['#title'] = $title;
+            }
         }
 
         if ($type === self::WM_EMBED_TYPE_VIMEO) {
@@ -46,6 +50,10 @@ class VideoEmbedder
                 '#autoplay' => $autoplay,
                 '#keyboard' => $disableKeyboard ? 'false' : 'true',
             ];
+
+            if ($title) {
+                $build['#title'] = $title;
+            }
         }
 
         if (is_array($build)) {

--- a/src/VideoEmbedder.php
+++ b/src/VideoEmbedder.php
@@ -8,7 +8,7 @@ class VideoEmbedder
     public const WM_EMBED_TYPE_YOUTUBE_SHORT = 'youtube_short';
     public const WM_EMBED_TYPE_VIMEO = 'vimeo';
 
-    public static function create($url, $autoplay = false, ?int $width = null, ?int $height = null): ?array
+    public static function create($url, $autoplay = false, ?int $width = null, ?int $height = null, bool $disableKeyboard = true, ?string $title = null): ?array
     {
         [$type, $vid] = \Drupal::service('wmvideo.url_parser')->parse($url);
 
@@ -33,6 +33,7 @@ class VideoEmbedder
                 '#autoplay' => $autoplay,
                 '#lang' => $lang,
                 '#domain' => $domain,
+                '#disablekb' => $disableKeyboard ? '1' : '0',
             ];
         }
 
@@ -43,6 +44,7 @@ class VideoEmbedder
                 '#width' => $width,
                 '#height' => $height,
                 '#autoplay' => $autoplay,
+                '#keyboard' => $disableKeyboard ? 'false' : 'true',
             ];
         }
 

--- a/templates/wmvideo-vimeo.html.twig
+++ b/templates/wmvideo-vimeo.html.twig
@@ -1,4 +1,5 @@
 <iframe class="wm-embed wm-embed-vimeo"
+  title="{{ title }}"
   width="{{ width }}"
   height="{{ height }}"
   src="https://player.vimeo.com/video/{{ vid }}?portrait=0&amp;badge=0&amp;byline=0&amp;title=0&amp;color=fff&amp;autoplay={{ autoplay }}&amp;keyboard={{ keyboard }}"

--- a/templates/wmvideo-vimeo.html.twig
+++ b/templates/wmvideo-vimeo.html.twig
@@ -1,7 +1,7 @@
 <iframe class="wm-embed wm-embed-vimeo"
   width="{{ width }}"
   height="{{ height }}"
-  src="https://player.vimeo.com/video/{{ vid }}?portrait=0&amp;badge=0&amp;byline=0&amp;title=0&amp;color=fff&amp;autoplay={{ autoplay }}"
-  data-src="https://player.vimeo.com/video/{{ vid }}?portrait=0&amp;badge=0&amp;byline=0&amp;title=0&amp;color=fff&amp;autoplay={{ autoplay }}"
+  src="https://player.vimeo.com/video/{{ vid }}?portrait=0&amp;badge=0&amp;byline=0&amp;title=0&amp;color=fff&amp;autoplay={{ autoplay }}&amp;keyboard={{ keyboard }}"
+  data-src="https://player.vimeo.com/video/{{ vid }}?portrait=0&amp;badge=0&amp;byline=0&amp;title=0&amp;color=fff&amp;autoplay={{ autoplay }}&amp;keyboard={{ keyboard }}"
   allowfullscreen>
 </iframe>

--- a/templates/wmvideo-youtube.html.twig
+++ b/templates/wmvideo-youtube.html.twig
@@ -4,4 +4,5 @@
   src="https://www.youtube-nocookie.com/embed/{{ vid }}?origin={{ domain }}&amp;color=white&amp;autohide=1&amp;rel=0&amp;showinfo=0&amp;hl={{ lang }}&amp;wmode=opaque&amp;autoplay={{ autoplay }}"
   data-src="https://www.youtube-nocookie.com/embed/{{ vid }}?origin={{ domain }}&amp;color=white&amp;autohide=1&amp;rel=0&amp;showinfo=0&amp;hl={{ lang }}&amp;wmode=opaque&amp;autoplay={{ autoplay }}"
   allowfullscreen
+  disablekb={{ disablekb }}
 ></iframe>

--- a/templates/wmvideo-youtube.html.twig
+++ b/templates/wmvideo-youtube.html.twig
@@ -1,4 +1,5 @@
 <iframe class="wm-embed wm-embed-youtube"
+  title="{{ title }}"
   width="{{ width }}"
   height="{{ height }}"
   src="https://www.youtube-nocookie.com/embed/{{ vid }}?origin={{ domain }}&amp;color=white&amp;autohide=1&amp;rel=0&amp;showinfo=0&amp;hl={{ lang }}&amp;wmode=opaque&amp;autoplay={{ autoplay }}"

--- a/wmvideo.info.yml
+++ b/wmvideo.info.yml
@@ -2,7 +2,7 @@ name: Wieni Video
 type: module
 description: Converting a YouTube or Vimeo URL to an embedded player
 package: Wieni
-core_version_requirement: ">=10.1"
+core_version_requirement: ^9.3 || ^10
 dependencies:
     - link
     - filter

--- a/wmvideo.module
+++ b/wmvideo.module
@@ -31,6 +31,7 @@ function wmvideo_theme(): array
                 'origin' => null,
                 'autoplay' => false,
                 'disablekb' => '1',
+                'title' => "",
             ],
         ],
         'wmvideo_vimeo' => [
@@ -40,6 +41,7 @@ function wmvideo_theme(): array
                 'height' => 360,
                 'autoplay' => false,
                 'keyboard' => 'false',
+                'title' => "",
             ],
         ],
     ];

--- a/wmvideo.module
+++ b/wmvideo.module
@@ -30,6 +30,7 @@ function wmvideo_theme(): array
                 'lang' => 'en',
                 'origin' => null,
                 'autoplay' => false,
+                'disablekb' => '1',
             ],
         ],
         'wmvideo_vimeo' => [
@@ -38,6 +39,7 @@ function wmvideo_theme(): array
                 'width' => 640,
                 'height' => 360,
                 'autoplay' => false,
+                'keyboard' => 'false',
             ],
         ],
     ];


### PR DESCRIPTION
## Description

> * [Vimeo-snelkoppelingen kunnen interfereren met hulptechnologieën](https://app.caat.report/share/e3b3a87b-adeb-4179-b2d4-392c24925e6d#3e344e89-df16-42ab-88af-5dca07527b7f)
> * [YouTube-snelkoppelingen kunnen interfereren met hulptechnologieën](https://app.caat.report/share/e3b3a87b-adeb-4179-b2d4-392c24925e6d#21bfd173-a1aa-4441-95a9-86346e58e740)
> * [iframe voor video heeft geen toegankelijke naam](https://app.caat.report/share/e3b3a87b-adeb-4179-b2d4-392c24925e6d#aaf5285d-bd39-4c0e-8e07-5b35a1fd7ed2)

Also added back compatibility to older GuzzleHttp versions and Drupal ^9.3
### Documentation



## Related Issues

changes required for issue https://github.com/wieni/www.mediawijs.be/issues/83
