### PR TITLE
Add groups url format to parser

### DIFF
--- a/src/Service/UrlParser.php
+++ b/src/Service/UrlParser.php
@@ -53,6 +53,8 @@ class UrlParser
 
             if (preg_match('#^/video/(?<vid>.+)#', $url['path'], $matches)) {
                 $vid = $matches['vid'];
+            } elseif (preg_match('#^/groups/\d+/videos/(?<vid>.+)#', $url['path'], $matches)) {
+                $vid = $matches['vid'];
             } elseif (preg_match('#^/(?<vid>.+)/.+$#', $url['path'], $matches)) {
                 $vid = $matches['vid'];
             } else {


### PR DESCRIPTION
## Description

the current url parser does not handle videos from vimeo of the format https://vimeo.com/groups/114/videos/1017406920
