### PR TITLE
Replace deprecated Guzzle Utils::jsonDecode()

### DIFF
--- a/src/Service/VideoInfo.php
+++ b/src/Service/VideoInfo.php
@@ -4,8 +4,6 @@ namespace Drupal\wmvideo\Service;
 
 use Drupal\wmvideo\VideoEmbedder;
 use GuzzleHttp\Client;
-use GuzzleHttp\Utils;
-use function GuzzleHttp\json_decode;
 use GuzzleHttp\RequestOptions;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -47,7 +45,11 @@ class VideoInfo
 
         try {
             $response = $this->client->get($url, $options);
-            $body = Utils::jsonDecode($response->getBody()->getContents(), true);
+            // Guzzle's Utils::jsonDecode() is deprecated and is removed in
+            // guzzlehttp/guzzle:8.0. json_decode() with JSON_THROW_ON_ERROR is
+            // equivalent here: the JsonException it throws on a malformed body
+            // is caught below, just like Guzzle's InvalidArgumentException was.
+            $body = json_decode($response->getBody()->getContents(), true, 512, \JSON_THROW_ON_ERROR);
         } catch (\Exception $e) {
             return null;
         }


### PR DESCRIPTION
`GuzzleHttp\Utils::jsonDecode()` is deprecated and **removed in guzzlehttp/guzzle:8.0**, which is now released. Any consuming project that moves to Guzzle 8 gets a fatal in `VideoInfo::getInfo()`.

## Change

- `Utils::jsonDecode($json, true)` → `json_decode($json, true, 512, JSON_THROW_ON_ERROR)`.
  Behaviour-preserving: on a malformed body Guzzle threw `InvalidArgumentException`, this throws `JsonException`. Both extend `\Exception`, and the call sits inside `try { … } catch (\Exception $e) { return null; }`, so the malformed-response path still returns `null`.
- Dropped the unused `use function GuzzleHttp\json_decode;` import — that pointed at the pre-7.x procedural helper Guzzle had already removed.

## Compatibility

Works unchanged on Guzzle 7 and 8, so no version gating (`DeprecationHelper` or otherwise) is needed. No core-version dependency.

## How it was found

`drupal/upgrade_status` 5.0.0-alpha3 scan while verifying www.uzleuven.be on Drupal 11.4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)